### PR TITLE
Add CopyLocalGuideImgResources Gradle tasks

### DIFF
--- a/gradle/guide-build.gradle
+++ b/gradle/guide-build.gradle
@@ -93,3 +93,15 @@ task updateGuidesJson() << {
 
     f.text = JsonOutput.toJson(json)
 }
+
+task copyLocalGuideImgResources(type: Copy) {
+    from ('src/main/resources/img') {
+        include '*.png'
+        include '*.gif'
+        include '*.jpg'
+        include '*.jpeg'
+    }
+    into "${buildDir}/resources/grails-guides-master/src/main/resources/img"
+}
+publishGuide.dependsOn copyLocalGuideImgResources
+copyLocalGuideImgResources.mustRunAfter prepareResources


### PR DESCRIPTION
it merges the images present in the root grails-guides project with the images of the local guide