### PR TITLE
Fix create-guide.sh so gradle wrapper command is successful

### DIFF
--- a/create-guide.sh
+++ b/create-guide.sh
@@ -12,7 +12,8 @@ if [[ -n $GUIDE_NAME ]]; then
     mv $GUIDE_NAME initial
     mkdir complete
     cp -rf initial/* complete/
-    echo "include 'complete', 'initial'" > settings.gradle
+    # Replace rootProject.name="$GUIDE_NAME"  with  include 'complete', 'initial'
+    sed "s/rootProject.name=\"${GUIDE_NAME}\"/include 'complete', 'initial'/" initial/settings.gradle > settings.gradle
     cp -rf ../src/main/project/* .
     gradle wrapper
 

--- a/src/main/docs/common-requirements-grails4.adoc
+++ b/src/main/docs/common-requirements-grails4.adoc
@@ -2,4 +2,4 @@ To complete this guide, you will need the following:
 
 * Some time on your hands
 * A decent text editor or IDE
-* JDK 11 or greater installed with `JAVA_HOME` configured appropriately
+* JDK 1.8 or greater installed with `JAVA_HOME` configured appropriately


### PR DESCRIPTION
Modified the `create-guide.sh` script so that it succeeds when using Java 11, Grails 6.2.0 and Gradle 7.6.4. 

Before, running the script (while on the 6.0.x branch) `./create-guide.sh adding-config-info` would fail like so:
```
| Application created at /Users/tylervanzanten/src/grails_docs/grails-guides/grails-guides/adding-config-info/adding-config-info

FAILURE: Build failed with an exception.

* Where:
Build file '/Users/tylervanzanten/src/grails_docs/grails-guides/grails-guides/adding-config-info/complete/build.gradle' line: 3

* What went wrong:
Plugin [id: 'org.grails.grails-web'] was not found in any of the following sources:

- Gradle Core Plugins (plugin is not in 'org.gradle' namespace)
- Plugin Repositories (plugin dependency must include a version number for this source)
```

I modified the script so that it copies the `initial/settings.gradle` file into `settings.gradle` and replaces the last line with `"include 'complete', 'initial'"`. The resulting `settings.gradle` file looks like:
```groovy

pluginManagement {
    repositories {
        mavenLocal()
        maven { url "https://repo.grails.org/grails/core/" }
        gradlePluginPortal()
    }
    plugins {
        id "org.grails.grails-web" version "6.1.2"
        id "org.grails.grails-gsp" version "6.1.2"
        id "com.bertramlabs.asset-pipeline" version "4.3.0"
        id "com.github.erdi.webdriver-binaries" version "3.2"
    }
}

include 'complete', 'initial'

```

I also updated the requirements to state that JDK 11 is needed for Grails 6 applications, as stated in the [documentation](https://docs.grails.org/6.2.0/guide/single.html#requirements).