### PR TITLE
Fix publishGuide task

### DIFF
--- a/gradle/guide-build.gradle
+++ b/gradle/guide-build.gradle
@@ -5,7 +5,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "org.grails:grails-docs:6.0.0-RC1"
+        classpath "org.grails:grails-docs:6.2.0"
     }
 }
 
@@ -49,7 +49,6 @@ task publishGuide(type: grails.doc.gradle.PublishGuide) {
     dependsOn prepareResources, copyLocalGuideImgResources
 
     def localResourcesDir = "${buildDir}/resources/${commonGithubSlug}-${commonBranch}"
-    // def localResourcesDir = "../grails-guides/"
     // No language setting because we want the English guide to be
     // generated with a 'en' in the path, but the source is in 'en'
     // so that it's easy to track with git.
@@ -59,6 +58,10 @@ task publishGuide(type: grails.doc.gradle.PublishGuide) {
     propertiesFiles = [ new File(projectDir, "gradle.properties"), new File(projectDir, "complete/gradle.properties") ]
     asciidoc = true
     resourcesDir = project.file("${localResourcesDir}/src/main/resources")
+    // Create the directory if it does not exist
+    if (!resourcesDir.exists()) {
+        resourcesDir.mkdirs()
+    }
     properties = [   
         'safe':'UNSAFE',
         'commondir':project.file("${localResourcesDir}/src/main/docs"),


### PR DESCRIPTION
Fix the `publishGuide` task so that it succeeds for guides that are generated using Java 11, Grails 6.2.0 and Gradle 7.6.4.

Before this fix, I had to create a `src/main/resources/img` directory (in my Grails guide project) with an image file in it in order for `./gradlew publishGuide` to work. Otherwise I'd get this error:
```
> Task :publishGuide FAILED

FAILURE: Build failed with an exception.

* What went wrong:
A problem was found with the configuration of task ':publishGuide' (type 'PublishGuide').
  - Type 'grails.doc.gradle.PublishGuide' property 'resourcesDir' specifies directory '/Users/tylervanzanten/src/grails_docs/adding-build-info/adding-build-info/build/resources/grails-guides-6.0.x/src/main/resources' which doesn't exist.
    
    Reason: An input file was expected to be present but it doesn't exist.
    
    Possible solutions:
      1. Make sure the directory exists before the task is called.
      2. Make sure that the task which produces the directory is declared as an input.
    
    Please refer to https://docs.gradle.org/7.6.4/userguide/validation_problems.html#input_file_does_not_exist for more details about this problem.
```

Creating a `src/main/resources/img` directory (in my Grails guide project) with an image file in it is a temporary workaround because then the `copyLocalGuideImgResources` task gets executed beforehand and creates the directory `build/resources/grails-guides-6.0.x/src/main/resources`.